### PR TITLE
Fix dsp_homebrew script

### DIFF
--- a/python-scripts/dsp_homebrew.py
+++ b/python-scripts/dsp_homebrew.py
@@ -11,20 +11,29 @@ import time
 def dsp_homebrew():
   #FIXME: Pass dsp object which provides all the device details and registers instead
 
-  # Disable DSP
-  apu.write_u32(NV_PAPU_GPRST, NV_PAPU_GPRST_GPRST) # If this is zero, the GP will not allow reads/writes to memory?!
+  # Reset GP and GP DSP
+  apu.write_u32(NV_PAPU_GPRST, 0)
   time.sleep(0.1) # FIXME: Not sure if DSP reset is synchronous, so we wait for now
 
+  # Enable GP first, otherwise memory writes won't be handled
+  apu.write_u32(NV_PAPU_GPRST, NV_PAPU_GPRST_GPRST)
+
   # Allocate some scratch space (at least 2 pages!)
-  #FIXME: Free memory after running
+  #FIXME: Why did I put: "(at least 2 pages!)" ?
   page_count = 2
-  page_head = ke.MmAllocateContiguousMemory(4096)
-  apu.write_u32(NV_PAPU_GPSADDR, ke.MmGetPhysicalAddress(page_head))
+
+  # Apparently NV_PAPU_GPSADDR has to be aligned to 0x4000 bytes?!
+  #FIXME: Free memory after running
+  page_head = ke.MmAllocateContiguousMemoryEx(4096, 0x00000000, 0xFFFFFFFF, 0x4000, ke.PAGE_READWRITE)
+  page_head_p = ke.MmGetPhysicalAddress(page_head)
+  apu.write_u32(NV_PAPU_GPSADDR, page_head_p)
   page_base = ke.MmAllocateContiguousMemory(4096 * page_count)
   for i in range(0, page_count):
     write_u32(page_head + i * 8 + 0, ke.MmGetPhysicalAddress(page_base + 0x1000 * i))
     write_u32(page_head + i * 8 + 4, 0) # Control
-  apu.write_u32(NV_PAPU_GPSMAXSGE, page_count - 1)
+
+  # I'm not sure if this is off-by-one (maybe `page_count - 1`)
+  apu.write_u32(NV_PAPU_GPSMAXSGE, page_count)
 
   # It was assembled using `a56 loop.inc && toomf < a56.out`.
   # The resulting code was then copied here.
@@ -57,50 +66,59 @@ def dsp_homebrew():
   # Convert the 24 bit words to 32 bit words
   data = dsp.from24(data)
 
-  while True:
+  # Write code to PMEM (normally you can just use write() but we don't support that for apu MMIO yet.. boo!)
+  for i in range(0, len(data) // 4):
+    word = int.from_bytes(data[i*4:i*4+4], byteorder='little', signed=False) & 0xFFFFFF
+    apu.write_u32(NV_PAPU_GPPMEM + i*4, word)
+    # According to XQEMU, 0x800 * 4 bytes will be loaded from scratch to PMEM at startup.
+    # So just to be sure, let's also write this to the scratch..
+    write_u32(page_base + i*4, word)
 
-    # Write code to PMEM (normally you can just use write() but we don't support that for apu MMIO yet.. boo!)
-    for i in range(0, len(data) // 4):
-      word = int.from_bytes(data[i*4:i*4+4], byteorder='little', signed=False) & 0xFFFFFF
-      apu.write_u32(NV_PAPU_GPPMEM + i*4, word)
-      # According to XQEMU, 0x800 * 4 bytes will be loaded from scratch to PMEM at startup.
-      # So just to be sure, let's also write this to the scratch..
-      write_u32(page_base + i*4, word)
 
-    # Set XMEM
-    apu.write_u32(NV_PAPU_GPXMEM + 0*4, 0x001337)
+  # Set XMEM
+  apu.write_u32(NV_PAPU_GPXMEM + 0*4, 0x001337)
 
-    # Set YMEM
-    apu.write_u32(NV_PAPU_GPYMEM + 0*4, 0x000000)
+  # Set YMEM
+  apu.write_u32(NV_PAPU_GPYMEM + 0*4, 0x000000)
 
-    # Test readback
-    print("Read back X[0]:0x" + format(apu.read_u32(NV_PAPU_GPXMEM + 0*4), '06X'))
-    print("Read back Y[0]:0x" + format(apu.read_u32(NV_PAPU_GPYMEM + 0*4), '06X'))
+  # Test readback
+  print("Read back X[0]:0x" + format(apu.read_u32(NV_PAPU_GPXMEM + 0*4), '06X'))
+  print("Read back Y[0]:0x" + format(apu.read_u32(NV_PAPU_GPYMEM + 0*4), '06X'))
 
-    print("Read back P[0]:0x" + format(apu.read_u32(NV_PAPU_GPPMEM + 0*4), '06X'))
-    print("Read back P[1]:0x" + format(apu.read_u32(NV_PAPU_GPPMEM + 1*4), '06X'))
+  print("Read back P[0]:0x" + format(apu.read_u32(NV_PAPU_GPPMEM + 0*4), '06X'))
+  print("Read back P[1]:0x" + format(apu.read_u32(NV_PAPU_GPPMEM + 1*4), '06X'))
 
-    # Set frame duration (?!)
+  # Set frame duration (?!)
+  if False:
     apu.write_u32(NV_PAPU_SECTL, 3 << 3)
 
-    # Enable DSP
-    # NV_PAPU_GPRST_GPRST < crashes!
-    # NV_PAPU_GPRST_GPDSPRST < works!
-    apu.write_u32(NV_PAPU_GPRST, NV_PAPU_GPRST_GPRST | NV_PAPU_GPRST_GPDSPRST)
-    time.sleep(0.1)
+  # Mark GP as ready?
+  NV_PAPU_GPIDRDY = 0x3FF10
+  NV_PAPU_GPIDRDY_GPSETIDLE = (1 << 0)
+  apu.write_u32(NV_PAPU_GPIDRDY, NV_PAPU_GPIDRDY_GPSETIDLE)
 
-    # Write X again. Bootcode in the DSP seems to overwrites XMEM + YMEM
-    apu.write_u32(NV_PAPU_GPXMEM + 0*4, 0x001338)
+  # Clear interrupts
+  NV_PAPU_GPISTS = 0x3FF14
+  apu.write_u32(NV_PAPU_GPISTS, 0xFF)
 
-    time.sleep(0.5)
+  # Now run GP DSP by removing reset bit
+  apu.write_u32(NV_PAPU_GPRST, NV_PAPU_GPRST_GPRST | NV_PAPU_GPRST_GPDSPRST)
+  time.sleep(0.1)
 
-    #if (apu.read_u32(NV_PAPU_GPXMEM + 0*4) == 0x1338):
-    #  continue
 
-    # Read destination data from YMEM
-    #while True:
-    print("Read back X[0]:0x" + format(apu.read_u32(NV_PAPU_GPXMEM + 0*4), '06X'))
-    print("Read back Y[0]:0x" + format(apu.read_u32(NV_PAPU_GPYMEM + 0*4), '06X'))
+  # Read destination data from YMEM
+  t = 0
+  while True:
+    # Write X again. Bootcode in the DSP seems to overwrite XMEM + YMEM
+    t += 1
+    apu.write_u32(NV_PAPU_GPXMEM + 0*4, t)
+    apu.write_u32(NV_PAPU_GPYMEM + 0*4, 0x00DEAD)
+    i = 0
+    print("")
+    print("Read back S[%i]:0x%06X" % (i, read_u32(page_base + i*4)))
+    print("Read back P[%i]:0x%06X" % (i, apu.read_u32(NV_PAPU_GPPMEM + i*4)))
+    print("Read back X[%i]:0x%06X" % (i, apu.read_u32(NV_PAPU_GPXMEM + i*4)))
+    print("Read back Y[%i]:0x%06X" % (i, apu.read_u32(NV_PAPU_GPYMEM + i*4)))
     time.sleep(0.5)
 
 


### PR DESCRIPTION
This was tested using XBDM and had a much much better success rate (100%)
My XDK dashboard (which I used to test this script) would sometimes freeze (but CPU + DSP were still functional). I'm not sure if this was an cable issue or a bug with my DSP hackery. My Xbox also decided to crash when starting a new XBE.

I've done a handful of changes and also made it closer to what the original DirectSound code is doing.
I think the most important change was aligning `NV_PAPU_GPSADDR` to 0x4000 bytes after noticing that read-backs of that register would be broken almost always.
As PMEM is loaded from scratch space, this meant that random data was loaded as code.

Some comments might still be outdated, but this is probably a lot more stable and easier to work with than the old code. Code can be cleaned up iteratively.

This hopefully closes #15.

Depends on #57.