### PR TITLE
Add a tool to inject and run code

### DIFF
--- a/python-scripts/inject_code.py
+++ b/python-scripts/inject_code.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+# Injects code and runs it
+
+from xboxpy import *
+
+import sys
+
+f = open(sys.argv[1], 'rb')
+code = f.read()
+
+pointer = ke.MmAllocateContiguousMemory(len(code))
+memory.write(pointer, code)
+api.call(pointer, bytes([]))
+ke.MmFreeContiguousMemory(pointer)


### PR DESCRIPTION
This is fairly simple.. I'm using it to do low-level experiments (who needs a kernel anyway?).

Can be used with nasm output: `nasm smc_led.asm && ./inject_code smc_led`

```asm
  ; This is smc_led.asm

start:

  ; Set SMC LED mode to manual
  push 0x01
  push 0x07
  call write_smc

  ; Set SMC LED color to red
  push 0xF0
  push 0x08
  call write_smc

  ret

write_smc:

  pop edi

  ; Write SMBus address
  mov dx, 0xC004
  mov al, 0x20
  out dx, al

  ; Write SMBus command
  mov dx, 0xC008
  pop eax
  out dx, al

  ; Write SMBus data
  mov dx, 0xC006
  pop eax
  out dx, al

  ; Clear SMBus status?
  mov dx, 0xC000
  in ax, dx
  out dx, ax

  ; Write SMBus control
  mov dx, 0xC002
  mov al, 0x0A ; 0x0B for word size
  out dx, al

  ; Wait until SMBus isn't busy anymore
  mov dx, 0xC000
  write_smc_busy:
    in ax, dx
    test ax, 0x0008
  jnz write_smc_busy

  push edi

  ret
```

We can later add an option to push arguments from the command line, and dump out a return value; however, for now, this is probably fine as-is.