### PR TITLE
Add tools to fill and dump memory

### DIFF
--- a/python-scripts/dump_dsp.py
+++ b/python-scripts/dump_dsp.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+# Dumps the DSP memory
+
+from xboxpy import *
+import struct
+
+f = open('dsp.bin', 'wb')
+
+data = []
+
+print("GP P")
+for i in range(4096):
+  data += [apu.read_u32(NV_PAPU_GPPMEM + i*4)]
+print("GP X")
+for i in range(4096):
+  data += [apu.read_u32(NV_PAPU_GPXMEM + i*4)]
+print("GP Y")
+for i in range(2048):
+  data += [apu.read_u32(NV_PAPU_GPYMEM + i*4)]
+print("GP MIXBUF")
+for i in range(1024):
+  data += [apu.read_u32(NV_PAPU_GPMIXBUF + i*4)]
+
+print("EP P")
+for i in range(4096):
+  data += [apu.read_u32(NV_PAPU_EPPMEM + i*4)]
+print("EP X")
+for i in range(3072):
+  data += [apu.read_u32(NV_PAPU_EPXMEM + i*4)]
+print("EP Y")
+for i in range(256):
+  data += [apu.read_u32(NV_PAPU_EPYMEM + i*4)]
+
+
+encoded = bytes(sum([list(struct.pack("<I", x)) for x in data], list()))
+f.write(encoded)
+
+f.close()

--- a/python-scripts/dump_ram.py
+++ b/python-scripts/dump_ram.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+# Read all physical memory
+
+from xboxpy import *
+
+ram_size = 64 * 1024 * 1024
+
+f = open('ram.bin', 'wb')
+
+offset = 0
+chunk_size = 0x1000
+assert(ram_size % chunk_size == 0)
+while offset < ram_size:
+  mapped = ke.MmMapIoSpace(offset, chunk_size, ke.PAGE_READWRITE)
+  data = memory.read(mapped, chunk_size)
+  f.write(data)
+  ke.MmUnmapIoSpace(mapped, chunk_size)
+  offset += chunk_size
+
+f.close()

--- a/python-scripts/fill_dsp.py
+++ b/python-scripts/fill_dsp.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+# Fills the DSP memory with known pattern
+
+from xboxpy import *
+
+print("GP P")
+for i in range(4096):
+  apu.write_u32(NV_PAPU_GPPMEM + i*4, 0x313373)
+print("GP X")
+for i in range(4096):
+  apu.write_u32(NV_PAPU_GPXMEM + i*4, 0x313373)
+print("GP Y")
+for i in range(2048):
+  apu.write_u32(NV_PAPU_GPYMEM + i*4, 0x313373)
+print("GP MIXBUF")
+for i in range(1024):
+  apu.write_u32(NV_PAPU_GPMIXBUF + i*4, 0x313373)
+
+print("EP P")
+for i in range(4096):
+  apu.write_u32(NV_PAPU_EPPMEM + i*4, 0x313373)
+print("EP X")
+for i in range(3072):
+  apu.write_u32(NV_PAPU_EPXMEM + i*4, 0x313373)
+print("EP Y")
+for i in range(256):
+  apu.write_u32(NV_PAPU_EPYMEM + i*4, 0x313373)

--- a/python-scripts/fill_ram.py
+++ b/python-scripts/fill_ram.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+# Search empty memory regions and fill them with a pattern
+
+from xboxpy import *
+
+pattern = b'JayFoxRox'
+page_contents = (pattern * ((0x1000 // len(pattern) + 1)))[0:0x1000]
+print(len(page_contents))
+assert(len(page_contents) == 0x1000)
+
+ram_size = 64 * 1024 * 1024
+
+page_count = 0
+
+#FIXME: Walk the pagetable instead and map memory using MmMapIoSpace!
+offset = 0
+while offset < ram_size:
+  allocated = ke.MmAllocateContiguousMemoryEx(0x1000, offset, offset + 0x1000, 0x1000, ke.PAGE_READWRITE)
+  if allocated != 0:
+    memory.write(allocated, page_contents[0:len(pattern)])
+    print("Filling 0x%08X" % ke.MmGetPhysicalAddress(allocated))
+    ke.MmFreeContiguousMemory(allocated)
+    page_count += 1
+  offset += 0x1000
+
+print("Filled %d pages" % page_count)


### PR DESCRIPTION
This is quite hacky, so I'm a bit torn about keeping this on my repo.
It should definitely be enhanced if we keep it around so it doesn't look as dumb (using my name and 0x313373 as pattern; DSP layout being ugly too).

The main purpose of these tools is to test how long the Xbox RAM keeps the values intact after a shutdown / during a reboot. To our surprise, it seems to persist values just fine. I've personally tested around ~5 seconds manual shutdown / reboot and lost no memory. Someone else tested even longer periods and we still found matches.
I've then repeated the test with DSP memory which behaved in a similar way.

The [inspiration for this was this paper](https://jhalderm.com/pub/papers/coldboot-cacm09.pdf). The motivation behind applying these techniques to Xbox is to transfer memory or DMA command blocks across a boot.