### PR TITLE
Port dump-xbox EEPROM and flash dumper to xboxpy

### DIFF
--- a/python-scripts/dump-eeprom.py
+++ b/python-scripts/dump-eeprom.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+# Dumps EEPROM image to eeprom.bin
+
+from xboxpy import *
+
+
+# Allocate a temporary ULONG
+tmp_ptr = ke.MmAllocateContiguousMemory(4)
+
+# Read EEPROM
+eeprom = bytes([])
+for i in range(0, 256, 2):
+
+  # Read 16-bit from EEPROM into a ULONG
+  ret = ke.HalReadSMBusValue(0xA9, i, ke.TRUE, tmp_ptr) # 0xA9 = EEPROM Read
+  assert(ret == 0)
+  tmp = memory.read_u32(tmp_ptr)
+
+  # Split the 16-bit word into 2 bytes
+  assert(tmp & ~0xFFFF == 0)
+  eeprom += bytes([tmp & 0xFF, (tmp >> 8) & 0xFF])
+
+# Free our temporary buffer
+ke.MmFreeContiguousMemory(tmp_ptr)
+
+# Output EEPROM image to file
+with open("eeprom.bin", "wb") as f:
+  f.write(eeprom)
+
+  print("Wrote EEPROM to eeprom.bin")

--- a/python-scripts/dump-flash.py
+++ b/python-scripts/dump-flash.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+# Dumps flash image to flash.bin
+
+from xboxpy import *
+
+
+# Assume that the flash is the maximum size (16 MiB)
+max_flash_size = 16*1024*1024
+
+# The last 512 byte of flash overlap the MCPX ROM.
+# However, if MCPX ROM is hidden, Xbox 1.1 and newer will crash on access.
+# So we only ever dump 8 MiB (16 MiB is unlikely anyway)
+max_flash_dump_size = max_flash_size // 2
+
+# Map flash into memory
+flash_ptr = ke.MmMapIoSpace(0xFF000000, max_flash_dump_size, ke.PAGE_READONLY | ke.PAGE_NOCACHE)
+
+flash = memory.read(flash_ptr, max_flash_dump_size)
+
+# Unmap flash
+ke.MmUnmapIoSpace(flash_ptr, max_flash_dump_size)
+
+# Try to find out the actual flash size
+while len(flash) > 1:
+
+  # Split the flash so the highest address bit is ignored
+  assert(len(flash) % 2 == 0)
+  first_half = flash[0:len(flash)//2]
+  second_half = flash[len(flash)//2:]
+
+  # If the parts are different, then we must keep both
+  if first_half != second_half:
+    break
+
+  # Only keep the first half
+  flash = first_half
+
+# Report flash trimming
+print("Assuming flash size of %u bytes (or duplicated contents)" % len(flash))
+
+# Warn about our limitations
+if len(flash) == max_flash_dump_size:
+  print()
+  print("The flash might be larger, this tool dumps at most %u bytes" % max_flash_dump_size)
+  print()
+
+# Output flash image to file
+with open("flash.bin", "wb") as f:
+  f.write(flash)
+
+  print("Wrote flash to flash.bin")


### PR DESCRIPTION
I'm trying to get rid of the old dump-xbox project.
This moves 2 more features into python-scripts.

I have tested the eeprom dumper in nxdk-rdt (worked). I assume the eeprom dumper also works using xbdm, but I did not test that.

I have tested the flash dumper using xbdm (worked).
It does not work using nxdk-rdt because of a bug in xboxpy (read is done in recursive loop which runs out of stack).
The flash dumper is fairly slow, especially in nxdk-rdt.

---

This doesn't work on master revisions yet:
- Depends on https://github.com/XboxDev/xboxpy/pull/32
- For nxdk-rdt, also depends on https://github.com/XboxDev/xboxpy/pull/31 in flash dumper